### PR TITLE
Fix package version resolved to 0.0.0 via setuptools-scm

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '21'
 macos_machine:
 - arm64-apple-darwin20.0.0
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-numpy:
-- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -44,6 +44,8 @@ tests:
         - fast_simplification
       pip_check: true
   - script:
+      - python -c "from importlib.metadata import version; v = version('fast_simplification'); assert v != '0.0.0', v"
+  - script:
       - pytest ./tests/
     files:
       source:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: fast-simplification
   version: 0.2.0
-  build_number: 0
+  build_number: 1
 
 package:
   name: ${{ name|lower }}
@@ -15,7 +15,10 @@ source:
 
 build:
   number: ${{ build_number }}
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    env:
+      SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}
 
 requirements:
   build:


### PR DESCRIPTION
This fixes the reported package version being `0.0.0` instead of the released version.

The upstream project derives its version dynamically via `setuptools-scm` (with `fallback_version = "0.0.0"`). When building from the GitHub release tarball there is no git metadata available, so `setuptools-scm` falls back to `0.0.0`. This sets `SETUPTOOLS_SCM_PRETEND_VERSION` to the recipe `version` so the built package reports the correct release version (`0.2.0`), and bumps the build number since the version is unchanged.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
